### PR TITLE
prevent cart from resseting when toggle open/close

### DIFF
--- a/src/components/cart/Cart.tsx
+++ b/src/components/cart/Cart.tsx
@@ -15,10 +15,14 @@ export const Cart = (props: {
 }) => {
   createEffect(() => {
     props.initialCart && updateCart(props.initialCart)
+  })
+
+  createEffect(() => {
     isCartOpen()
       ? document.body.classList.add('overflow-hidden')
       : document.body.classList.remove('overflow-hidden')
   })
+
   return (
     <Show when={isCartOpen()}>
       <div


### PR DESCRIPTION
Split createEffect into two separate effect to avoid cart state being reset to initialCart every time isCartOpen() changes